### PR TITLE
New variable for delay times

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,15 +6,15 @@ provider "azurerm" {
 # automation
 
 module "automation_account" {
-  source            = "../modules/automation_account"
-  for_each          = var.automation_accounts
-  resource_group    = each.key
-  script_templates  = lookup(each.value, "script_templates", [
-    "start-vms", 
+  source         = "../modules/automation_account"
+  for_each       = var.automation_accounts
+  resource_group = each.key
+  script_templates = lookup(each.value, "script_templates", [
+    "start-vms",
     "stop-vms"
   ])
-  schedules         = lookup(each.value, "schedules", var.schedules)
-  job_schedules     = lookup(each.value, "job_schedules", [
+  schedules = lookup(each.value, "schedules", var.schedules)
+  job_schedules = lookup(each.value, "job_schedules", [
     {
       schedule = "weekdays 6am"
       script   = "start-vms"
@@ -24,4 +24,5 @@ module "automation_account" {
       script   = "stop-vms"
     }
   ])
+  delay_between_groups = lookup(each.value, "delay_between_groups", 180)
 }

--- a/modules/automation_account/automation_scripts/start-vms.ps1.tmpl
+++ b/modules/automation_account/automation_scripts/start-vms.ps1.tmpl
@@ -3,7 +3,7 @@ workflow start-vms
     # vars
     $resourceGroup = "${resource_group}"
     $sequence_tag  = 'sequence_start'
-    $delayBetweenGroups = ${delay_between_groups}
+    $delayBetweenGroups = "${delay_between_groups}"
     
     # login - need to have managed identity for this to work https://docs.microsoft.com/en-us/azure/automation/enable-managed-identity-for-automation
     Connect-AzureRMAccount -Identity

--- a/modules/automation_account/automation_scripts/start-vms.ps1.tmpl
+++ b/modules/automation_account/automation_scripts/start-vms.ps1.tmpl
@@ -3,7 +3,7 @@ workflow start-vms
     # vars
     $resourceGroup = "${resource_group}"
     $sequence_tag  = 'sequence_start'
-    $delay_between_groups = 180
+    $delay_between_groups = ${delay_between_groups}
     
     # login - need to have managed identity for this to work https://docs.microsoft.com/en-us/azure/automation/enable-managed-identity-for-automation
     Connect-AzureRMAccount -Identity

--- a/modules/automation_account/automation_scripts/start-vms.ps1.tmpl
+++ b/modules/automation_account/automation_scripts/start-vms.ps1.tmpl
@@ -3,7 +3,7 @@ workflow start-vms
     # vars
     $resourceGroup = "${resource_group}"
     $sequence_tag  = 'sequence_start'
-    $delay_between_groups = ${delay_between_groups}
+    $delayBetweenGroups = ${delay_between_groups}
     
     # login - need to have managed identity for this to work https://docs.microsoft.com/en-us/azure/automation/enable-managed-identity-for-automation
     Connect-AzureRMAccount -Identity
@@ -96,6 +96,6 @@ workflow start-vms
             }
         }
         # add delay between groups
-        Start-Sleep -Seconds $delay_between_groups
+        Start-Sleep -Seconds $delayBetweenGroups
     }
 }

--- a/modules/automation_account/automation_scripts/stop-vms.ps1.tmpl
+++ b/modules/automation_account/automation_scripts/stop-vms.ps1.tmpl
@@ -3,7 +3,7 @@ workflow stop-vms
     # vars
     $resourceGroup = "${resource_group}"
     $sequence_tag  = 'sequence_stop'
-    $delay_between_groups = 180
+    $delay_between_groups = ${delay_between_groups}
     
     # login - need to have managed identity for this to work https://docs.microsoft.com/en-us/azure/automation/enable-managed-identity-for-automation
     Connect-AzureRMAccount -Identity

--- a/modules/automation_account/automation_scripts/stop-vms.ps1.tmpl
+++ b/modules/automation_account/automation_scripts/stop-vms.ps1.tmpl
@@ -3,7 +3,7 @@ workflow stop-vms
     # vars
     $resourceGroup = "${resource_group}"
     $sequence_tag  = 'sequence_stop'
-    $delay_between_groups = ${delay_between_groups}
+    $delayBetweenGroups = ${delay_between_groups}
     
     # login - need to have managed identity for this to work https://docs.microsoft.com/en-us/azure/automation/enable-managed-identity-for-automation
     Connect-AzureRMAccount -Identity
@@ -96,6 +96,6 @@ workflow stop-vms
             }
         }
         # add delay between groups
-        Start-Sleep -Seconds $delay_between_groups
+        Start-Sleep -Seconds $delayBetweenGroups
     }
 }

--- a/modules/automation_account/automation_scripts/stop-vms.ps1.tmpl
+++ b/modules/automation_account/automation_scripts/stop-vms.ps1.tmpl
@@ -3,7 +3,7 @@ workflow stop-vms
     # vars
     $resourceGroup = "${resource_group}"
     $sequence_tag  = 'sequence_stop'
-    $delayBetweenGroups = ${delay_between_groups}
+    $delayBetweenGroups = "${delay_between_groups}"
     
     # login - need to have managed identity for this to work https://docs.microsoft.com/en-us/azure/automation/enable-managed-identity-for-automation
     Connect-AzureRMAccount -Identity

--- a/modules/automation_account/main.tf
+++ b/modules/automation_account/main.tf
@@ -50,7 +50,6 @@ resource "azurerm_automation_runbook" "runbooks" {
   content = templatefile("${path.module}/automation_scripts/${each.key}.ps1.tmpl", {
     resource_group       = azurerm_automation_account.automation_account.resource_group_name
     delay_between_groups = var.delay_between_groups
-
   })
 }
 

--- a/modules/automation_account/main.tf
+++ b/modules/automation_account/main.tf
@@ -1,4 +1,4 @@
-locals {  # currently working on
+locals { # currently working on
   current_time = timestamp()
   tomorrow     = formatdate("YYYY-MM-DD", timeadd(local.current_time, "24h"))
 }
@@ -47,13 +47,15 @@ resource "azurerm_automation_runbook" "runbooks" {
   log_verbose             = "true"
   log_progress            = "true"
   runbook_type            = "PowerShellWorkflow"
-  content                 = templatefile("${path.module}/automation_scripts/${each.key}.ps1.tmpl", { 
-    resource_group = azurerm_automation_account.automation_account.resource_group_name
+  content = templatefile("${path.module}/automation_scripts/${each.key}.ps1.tmpl", {
+    resource_group       = azurerm_automation_account.automation_account.resource_group_name
+    delay_between_groups = var.delay_between_groups
+
   })
 }
 
 resource "azurerm_automation_job_schedule" "job_schedules" {
-  for_each                = { for index, js in var.job_schedules: index => js }
+  for_each                = { for index, js in var.job_schedules : index => js }
   resource_group_name     = azurerm_automation_account.automation_account.resource_group_name
   automation_account_name = azurerm_automation_account.automation_account.name
   schedule_name           = each.value.schedule

--- a/modules/automation_account/variables.tf
+++ b/modules/automation_account/variables.tf
@@ -2,3 +2,4 @@ variable "resource_group" { type = string }
 variable "script_templates" { type = list(any) }
 variable "schedules" { type = map(any) }
 variable "job_schedules" { type = list(any) }
+variable "delay_between_groups" { type = number }

--- a/modules/automation_account/variables.tf
+++ b/modules/automation_account/variables.tf
@@ -1,4 +1,4 @@
-variable "resource_group"   { type = string }
-variable "script_templates" { type = list }
-variable "schedules"        { type = map }
-variable "job_schedules"    { type = list }
+variable "resource_group" { type = string }
+variable "script_templates" { type = list(any) }
+variable "schedules" { type = map(any) }
+variable "job_schedules" { type = list(any) }

--- a/noms_production_1/terraform.tfvars
+++ b/noms_production_1/terraform.tfvars
@@ -6,19 +6,21 @@
 # will set up shutdown/startup automation at 7pm, 6am UTC respectively
 
 automation_accounts = { # each named after resource group
-  nomis-bip-lsast   = {},
-  nomis-bip-preprod = {}
+  nomis-bip-lsast = {},
+  nomis-bip-preprod = {
+    "delay_between_groups" = 600
+  }
 }
 
 schedules = {
   "weekdays 6am" = {
-    week_days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-    time          = "06:00:00",
-    frequency     = "week"
+    week_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    time      = "06:00:00",
+    frequency = "week"
   },
   "weekdays 7pm" = {
-    week_days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-    time          = "19:00:00",
-    frequency     = "week"
+    week_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    time      = "19:00:00",
+    frequency = "week"
   }
 }

--- a/noms_production_2/main.tf
+++ b/noms_production_2/main.tf
@@ -24,4 +24,5 @@ module "automation_account" {
       script   = "start-vms"
     }
   ])
+  delay_between_groups = lookup(each.value, "delay_between_groups", 180)
 }


### PR DESCRIPTION
The `automation_account` module now accepts number variable `delay_between_groups`. The value of `delay_between_groups` is retrieved from the `automation_accounts` map found in the .tfvars files for each module.

This update is in response to a concierge issue raised by Tony McCallion. All three of his PPPMLH4HUJV000* VMs were started at the same time on Friday morning last week. This caused an issue which means that VM 03 now needs to be rebuilt.

Sequence group tags can be set in the Azure portal to determine the sequence in which groups of VMs are started and stopped. Tony's VMs were all in the same group for both start and stop, but I've now corrected this via the Azure portal. Currently, there is a 180 second wait time between each sequence group. Tony has requested that this is changed to 600 seconds (10 minutes) for his VMs.