### PR TITLE
Correcting timezone to match plan

### DIFF
--- a/modules/automation_account/main.tf
+++ b/modules/automation_account/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_automation_schedule" "schedules" {
   frequency               = each.value.frequency
   week_days               = each.value.week_days
   start_time              = "${local.tomorrow}T${each.value.time}Z"
-  timezone                = "UTC"
+  timezone                = "Etc/UTC"
   lifecycle {
     ignore_changes = [
       # Ignore changes to start_time, because if new needs to be 5 mins in future.


### PR DESCRIPTION
All three pipelines are currently failing. The Terraform plans are showing a change to the `timezone` values, from `"Etc/UTC"` to `"UTC"`, even though `"UTC"` is what's written in the code. This change is to simply match what's being shown in the plans.

The plans are failing not because of the `timezone` change, but because the `start_time` value is in the past. The `start_time` value was originally set around September-time earlier this year. Since then, the `lifecycle` meta-argument has been put in place to `ignore_changes` to the `start_time` value. If the `ignore_changes` argument was not used, Terraform would update the `start_time` with every run, and this is undesirable.