### PR TITLE
DSO-981: log analytics tidy up - remove noms-production-2 automation

### DIFF
--- a/noms_production_2/main.tf
+++ b/noms_production_2/main.tf
@@ -1,28 +1,30 @@
 provider "azurerm" {
+  tenant_id       = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
+  subscription_id = "1d95dcda-65b2-4273-81df-eb979c6b547b"
   features {}
 }
 
 ##
 # automation
 
-module "automation_account" {
-  source            = "../modules/automation_account"
-  for_each          = var.automation_accounts
-  resource_group    = each.key
-  script_templates  = lookup(each.value, "script_templates", [
-    "start-vms", 
-    "stop-vms"
-  ])
-  schedules         = lookup(each.value, "schedules", var.schedules)
-  job_schedules     = lookup(each.value, "job_schedules", [
-    {
-      schedule = "saturday 7am"
-      script   = "stop-vms"
-    },
-    {
-      schedule = "monday 7am"
-      script   = "start-vms"
-    }
-  ])
-  delay_between_groups = lookup(each.value, "delay_between_groups", 180)
-}
+#module "automation_account" {
+#  source            = "../modules/automation_account"
+#  for_each          = var.automation_accounts
+#  resource_group    = each.key
+#  script_templates  = lookup(each.value, "script_templates", [
+#    "start-vms", 
+#    "stop-vms"
+#  ])
+#  schedules         = lookup(each.value, "schedules", var.schedules)
+#  job_schedules     = lookup(each.value, "job_schedules", [
+#    {
+#      schedule = "saturday 7am"
+#      script   = "stop-vms"
+#    },
+#    {
+#      schedule = "monday 7am"
+#      script   = "start-vms"
+#    }
+#  ])
+#  delay_between_groups = lookup(each.value, "delay_between_groups", 180)
+#}

--- a/noms_production_2/terraform.tfvars
+++ b/noms_production_2/terraform.tfvars
@@ -6,18 +6,18 @@
 # will set up shutdown/startup automation at 7pm, 6am UTC respectively
 
 automation_accounts = { # each named after resource group
-  pp-oasys   = {}
+  pp-oasys = {}
 }
 
 schedules = {
   "saturday 7am" = {
-    week_days     = ["Saturday"],
-    time          = "07:00:00",
-    frequency     = "week"
+    week_days = ["Saturday"],
+    time      = "07:00:00",
+    frequency = "week"
   },
   "monday 7am" = {
-    week_days     = ["Monday"],
-    time          = "07:00:00",
-    frequency     = "week"
+    week_days = ["Monday"],
+    time      = "07:00:00",
+    frequency = "week"
   }
 }


### PR DESCRIPTION
The noms-production-2 configuration is not used, i.e. every single VM within pp-oasys has got an exception.
It was for testing a BODS upgrade VM, but that got moved into devtest.