### PR TITLE
DSO-981: migrate to shared log analytics + terraform fmt

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ module "automation_account" {
   resource_group       = each.key
   la_workspace_name    = var.la_workspace_name
   la_workspace_rg_name = var.la_workspace_rg_name
+  tags                 = lookup(each.value, "tags", {})
   script_templates = lookup(each.value, "script_templates", [
     "start-vms",
     "stop-vms"

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 provider "azurerm" {
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
   features {}
 }
 
@@ -6,9 +8,11 @@ provider "azurerm" {
 # automation
 
 module "automation_account" {
-  source         = "../modules/automation_account"
-  for_each       = var.automation_accounts
-  resource_group = each.key
+  source               = "../modules/automation_account"
+  for_each             = var.automation_accounts
+  resource_group       = each.key
+  la_workspace_name    = var.la_workspace_name
+  la_workspace_rg_name = var.la_workspace_rg_name
   script_templates = lookup(each.value, "script_templates", [
     "start-vms",
     "stop-vms"

--- a/modules/automation_account/main.tf
+++ b/modules/automation_account/main.tf
@@ -156,6 +156,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alert" {
   query          = <<-QUERY
   AzureDiagnostics 
   | where ResourceProvider == "MICROSOFT.AUTOMATION"
+  | where Resource =~ "${azurerm_automation_account.automation_account.name}"
   | where StreamType_s == "Error"
   | project TimeGenerated, JobId_g, RunbookName_s, _ResourceId, Resource, ResultDescription
   QUERY

--- a/modules/automation_account/variables.tf
+++ b/modules/automation_account/variables.tf
@@ -3,3 +3,5 @@ variable "script_templates" { type = list(any) }
 variable "schedules" { type = map(any) }
 variable "job_schedules" { type = list(any) }
 variable "delay_between_groups" { type = number }
+variable "la_workspace_name" { type = string }
+variable "la_workspace_rg_name" { type = string }

--- a/modules/automation_account/variables.tf
+++ b/modules/automation_account/variables.tf
@@ -5,3 +5,4 @@ variable "job_schedules" { type = list(any) }
 variable "delay_between_groups" { type = number }
 variable "la_workspace_name" { type = string }
 variable "la_workspace_rg_name" { type = string }
+variable "tags" { type = map(any) }

--- a/noms_dev_&_test_environments/terraform.tfvars
+++ b/noms_dev_&_test_environments/terraform.tfvars
@@ -12,10 +12,18 @@ la_workspace_rg_name = "noms-test-loganalytics"
 
 
 automation_accounts = { # each named after resource group
-  t1-oasys       = {},
-  t2-oasys       = {},
-  t1-prisonnomis = {},
-  nomis-bip-t1   = {}
+  t1-oasys = {
+    tags = { service = "OASys", application = "OASys", environment_name = "T1" }
+  },
+  t2-oasys = {
+    tags = { service = "OASys", application = "OASys", environment_name = "T2" }
+  },
+  t1-prisonnomis = {
+    tags = { service = "NOMIS", application = "NOMIS", environment_name = "T1" }
+  },
+  nomis-bip-t1 = {
+    tags = { service = "NOMIS", application = "BI", environment_name = "T1" }
+  }
 }
 
 schedules = {

--- a/noms_dev_&_test_environments/terraform.tfvars
+++ b/noms_dev_&_test_environments/terraform.tfvars
@@ -5,6 +5,12 @@
 #   some-resourcegroup {}
 # will set up shutdown/startup automation at 7pm, 6am UTC respectively
 
+tenant_id            = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
+subscription_id      = "b1f3cebb-4988-4ff9-9259-f02ad7744fcb"
+la_workspace_name    = "noms-test"
+la_workspace_rg_name = "noms-test-loganalytics"
+
+
 automation_accounts = { # each named after resource group
   t1-oasys       = {},
   t2-oasys       = {},
@@ -14,13 +20,13 @@ automation_accounts = { # each named after resource group
 
 schedules = {
   "weekdays 6am" = {
-    week_days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-    time          = "06:00:00",
-    frequency     = "week"
+    week_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    time      = "06:00:00",
+    frequency = "week"
   },
   "weekdays 7pm" = {
-    week_days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-    time          = "19:00:00",
-    frequency     = "week"
+    week_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    time      = "19:00:00",
+    frequency = "week"
   }
 }

--- a/noms_production_1/terraform.tfvars
+++ b/noms_production_1/terraform.tfvars
@@ -11,9 +11,12 @@ la_workspace_name    = "noms-prod1"
 la_workspace_rg_name = "noms-prod-loganalytics"
 
 automation_accounts = { # each named after resource group
-  nomis-bip-lsast = {},
+  nomis-bip-lsast = {
+    tags = { service = "NOMIS", application = "BI", environment_name = "lsast" }
+  },
   nomis-bip-preprod = {
     "delay_between_groups" = 600
+    tags = { service = "NOMIS", application = "BI", environment_name = "preprod" }
   }
 }
 

--- a/noms_production_1/terraform.tfvars
+++ b/noms_production_1/terraform.tfvars
@@ -5,6 +5,11 @@
 #   some-resourcegroup {}
 # will set up shutdown/startup automation at 7pm, 6am UTC respectively
 
+tenant_id            = "747381f4-e81f-4a43-bf68-ced6a1e14edf"
+subscription_id      = "1d95dcda-65b2-4273-81df-eb979c6b547b"
+la_workspace_name    = "noms-prod1"
+la_workspace_rg_name = "noms-prod-loganalytics"
+
 automation_accounts = { # each named after resource group
   nomis-bip-lsast = {},
   nomis-bip-preprod = {

--- a/variables.tf
+++ b/variables.tf
@@ -1,2 +1,6 @@
+variable "tenant_id" {}
+variable "subscription_id" {}
 variable "automation_accounts" {}
 variable "schedules" {}
+variable "la_workspace_name" {}
+variable "la_workspace_rg_name" {}


### PR DESCRIPTION
Don't create a new log analytics workspace per account.  Instead use existing noms-test/noms-prod1.
Also ran terraform fmt so ignore whitespace changes.
Added service/application/environment_name tags
Added tags to some extra resources