### PR TITLE
DSO-981: migrate t1-oasys automation to fixngo repo

### DIFF
--- a/noms_dev_&_test_environments/terraform.tfvars
+++ b/noms_dev_&_test_environments/terraform.tfvars
@@ -12,9 +12,6 @@ la_workspace_rg_name = "noms-test-loganalytics"
 
 
 automation_accounts = { # each named after resource group
-  t1-oasys = {
-    tags = { service = "OASys", application = "OASys", environment_name = "T1" }
-  },
   t2-oasys = {
     tags = { service = "OASys", application = "OASys", environment_name = "T2" }
   },


### PR DESCRIPTION
Part of refactor to consolidate number of log analytics workspaces.
Migrating t1-oasys automation to dso-infra-azure-fixngo repo, which uses the automation account associated with noms-test workspace.