### PR TITLE
DSO-981: migrate remaining devtest accounts to fixngo

### DIFF
--- a/noms_dev_&_test_environments/terraform.tfvars
+++ b/noms_dev_&_test_environments/terraform.tfvars
@@ -12,7 +12,6 @@ la_workspace_rg_name = "noms-test-loganalytics"
 
 
 automation_accounts = { # each named after resource group
-  }
 }
 
 schedules = {

--- a/noms_dev_&_test_environments/terraform.tfvars
+++ b/noms_dev_&_test_environments/terraform.tfvars
@@ -12,26 +12,8 @@ la_workspace_rg_name = "noms-test-loganalytics"
 
 
 automation_accounts = { # each named after resource group
-  t2-oasys = {
-    tags = { service = "OASys", application = "OASys", environment_name = "T2" }
-  },
-  t1-prisonnomis = {
-    tags = { service = "NOMIS", application = "NOMIS", environment_name = "T1" }
-  },
-  nomis-bip-t1 = {
-    tags = { service = "NOMIS", application = "BI", environment_name = "T1" }
   }
 }
 
 schedules = {
-  "weekdays 6am" = {
-    week_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-    time      = "06:00:00",
-    frequency = "week"
-  },
-  "weekdays 7pm" = {
-    week_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-    time      = "19:00:00",
-    frequency = "week"
-  }
 }


### PR DESCRIPTION
Part of the log analytics consolidation - migrate remaining devtest automation accounts to fixngo repo which will use noms-test log analytics and associated automation account